### PR TITLE
Make ColonyChain as HTTP API using serde-tc

### DIFF
--- a/colony-common/Cargo.toml
+++ b/colony-common/Cargo.toml
@@ -12,3 +12,6 @@ tokio = { version = "1.0", features = ["full"] }
 rust_decimal = "1.25.0"
 thiserror = "1.0"
 pbc-contract-common = { version = "0.0.0", path = "../contract-common"}
+serde-tc = "0.3.2"
+serde_json = { version = "1.0" }
+anyhow = { version = "1.0" }

--- a/colony-common/src/lib.rs
+++ b/colony-common/src/lib.rs
@@ -1,9 +1,9 @@
 pub mod test_suite;
 
-use async_trait::async_trait;
 use pbc_contract_common::*;
 use rust_decimal::prelude::*;
 use serde::{Deserialize, Serialize};
+use serde_tc::*;
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -33,7 +33,7 @@ pub struct ContractInfo {
 }
 
 /// An error that can occur when interacting with the contract.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Serialize, Deserialize, Clone)]
 pub enum Error {
     /// When there is a problem to access to the full node.
     #[error("connection error: {0}")]
@@ -78,10 +78,10 @@ pub enum Error {
 ///
 /// One trivial implementation of this trait would carry the address of the full node and
 /// the relayer account used to submit message delivering transactions.
-#[async_trait]
-pub trait ColonyChain {
+#[serde_tc_full]
+pub trait ColonyChain: Send + Sync {
     /// Returns the name of the chain.
-    fn get_chain_name(&self) -> String;
+    async fn get_chain_name(&self) -> String;
 
     /// Checks whether the chain is healthy and the full node is running.
     async fn check_connection(&self) -> Result<(), Error>;
@@ -144,3 +144,5 @@ pub trait ColonyChain {
         proof: MerkleProof,
     ) -> Result<(), Error>;
 }
+
+impl serde_tc::http::HttpInterface for dyn ColonyChain {}

--- a/explorer/Cargo.toml
+++ b/explorer/Cargo.toml
@@ -11,3 +11,12 @@ blake3 = "1.3.1"
 tokio = { version = "1.0", features = ["full"] }
 pbc-colony-common = { version = "0.0.0", path = "../colony-common"}
 pbc-node = { version = "0.0.0", path = "../node"}
+rust_decimal = "1.25.0"
+rust_decimal_macros = "1.25.0"
+pbc-contract-common = { version = "0.0.0", path = "../contract-common"}
+serde-tc = "0.3.2"
+serde_json = { version = "1.0" }
+anyhow = { version = "1.0" }
+
+[dev-dependencies]
+reqwest = { version = "0.11", features = ["json"] }

--- a/explorer/src/dummy.rs
+++ b/explorer/src/dummy.rs
@@ -1,0 +1,100 @@
+use async_trait::async_trait;
+use pbc_colony_common::*;
+use pbc_contract_common::*;
+use pbc_node::PbcApi;
+use rust_decimal::prelude::*;
+use rust_decimal_macros::dec;
+use std::collections::HashMap;
+
+/// A dummy implementation for `trait ColonyChain`.
+///
+/// This is usually for testing the webpage,
+/// as this trait will be directly served as the API of the explorer server.
+pub struct Dummy {}
+
+#[async_trait]
+impl PbcApi for Dummy {}
+
+#[async_trait]
+impl ColonyChain for Dummy {
+    async fn get_chain_name(&self) -> String {
+        "dummy".to_owned()
+    }
+
+    async fn check_connection(&self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn get_contract_list(&self) -> Result<Vec<ContractInfo>, Error> {
+        Ok(vec![
+            ContractInfo {
+                address: "0xabcd".to_owned(),
+                contract_type: ContractType::LightClient,
+                sequence: 0,
+            },
+            ContractInfo {
+                address: "0x1234".to_owned(),
+                contract_type: ContractType::Treasury,
+                sequence: 0,
+            },
+        ])
+    }
+
+    async fn get_relayer_account_info(&self) -> Result<(String, Decimal), Error> {
+        Ok(("0x12341234".to_owned(), dec!(12.34)))
+    }
+
+    async fn get_light_client_header(&self) -> Result<Header, Error> {
+        Ok("Hmm".to_owned())
+    }
+
+    async fn get_treasury_fungible_token_balance(&self) -> Result<HashMap<String, Decimal>, Error> {
+        Ok(vec![
+            ("Bitcoin".to_owned(), dec!(123.45)),
+            ("Ether".to_owned(), dec!(444.44)),
+        ]
+        .into_iter()
+        .collect())
+    }
+
+    async fn get_treasury_non_fungible_token_balance(
+        &self,
+    ) -> Result<Vec<(String, String)>, Error> {
+        Ok(vec![
+            ("BAYC".to_owned(), "1".to_owned()),
+            ("Sandbox Land".to_owned(), "2".to_owned()),
+        ])
+    }
+
+    async fn update_light_client(&self, _message: LightClientUpdateMessage) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn transfer_treasury_fungible_token(
+        &self,
+        _message: FungibleTokenTransferMessage,
+        _block_height: u64,
+        _proof: MerkleProof,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn transfer_treasury_non_fungible_token(
+        &self,
+        _message: NonFungibleTokenTransferMessage,
+        _block_height: u64,
+        _proof: MerkleProof,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn deliver_custom_order(
+        &self,
+        _contract_name: &str,
+        _message: CustomMessage,
+        _block_height: u64,
+        _proof: MerkleProof,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+}

--- a/explorer/src/lib.rs
+++ b/explorer/src/lib.rs
@@ -1,10 +1,41 @@
+mod dummy;
+
 use pbc_colony_common::*;
 use std::collections::HashMap;
+use std::sync::Arc;
 
+/// Runs a web server that provides useful information about the colony chains and PBC.
 pub async fn run(
-    _colony_chains: HashMap<String, Box<dyn ColonyChain>>,
+    port: u16,
+    mut colony_chains: HashMap<String, Arc<dyn ColonyChain>>,
     _pbc_api: Box<dyn pbc_node::PbcApi>,
 ) {
-    // Runs a web server that provides useful information about the colony chains and PBC.
-    unimplemented!()
+    colony_chains.insert("dummy".to_owned(), Arc::new(dummy::Dummy {}));
+    let colony_chains: HashMap<String, Arc<dyn serde_tc::http::HttpInterface>> = colony_chains
+        .into_iter()
+        .map(|(name, chain)| (name, serde_tc::http::create_http_object(chain)))
+        .collect();
+    serde_tc::http::run_server(port, colony_chains).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn check_connection() {
+        tokio::spawn(run(12000, HashMap::new(), Box::new(dummy::Dummy {})));
+
+        let client = reqwest::Client::new();
+        let response = client
+            .post("http://localhost:12000/dummy")
+            .header("content-type", "application/json")
+            .body(r#"{"method": "get_chain_name", "params": {}}"#)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        assert_eq!(response.json::<String>().await.unwrap(), "dummy");
+    }
 }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,3 +1,3 @@
-pub trait PbcApi {
+pub trait PbcApi: Send + Sync {
     // Submits transactions, query the state, and etc.
 }


### PR DESCRIPTION
`serde-tc` 랑 매크로 `serde-tc-full`는 주어진 trait을 POST only HTTP 서버로 만들어주는 라이브러리입니다.
제가 만든건데 아직 다큐멘테이션을 제대로 안해놔서 그냥 사용법 (꽤 직관적입니다) 이해하시고 넘어가면 됩니다.