### PR TITLE
Add near, polkadot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # beacon-chain
 The PDAO beacon chain, a.k.a PBC
 
+## Colony-chain-specific build
+```shell
+cargo build -p pdao-colony-contract-common --features polkadot
+```
+
 ## Explorer
 [Link](http://141.223.124.26:4100)

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -16,8 +16,8 @@ serde_json = { version = "1.0" }
 anyhow = { version = "1.0" }
 pdao-colony-common = { version = "0.1.0", path = "../colony-common"}
 pdao-pbc-node = { version = "0.0.0", path = "../node"}
-pdao-colony-contract-common = { version = "0.1.0", path = "../contract-common"}
-pdao-beacon-chain-common = { version = "0.0.0", path = "../common"}
+pdao-colony-contract-common = { version = "0.1.1", path = "../contract-common"}
+pdao-beacon-chain-common = { version = "0.0.1", path = "../common"}
 
 [dev-dependencies]
 reqwest = { version = "0.11", features = ["json"] }

--- a/colony-common/Cargo.toml
+++ b/colony-common/Cargo.toml
@@ -17,8 +17,8 @@ blake3 = "1.3.1"
 tokio = { version = "1.0", features = ["full"] }
 rust_decimal = "1.25.0"
 thiserror = "1.0"
-pdao-colony-contract-common = { version = "0.1.0", path = "../contract-common"}
-pdao-beacon-chain-common = { version = "0.0.0", path = "../common"}
+pdao-colony-contract-common = { version = "0.1.1", path = "../contract-common"}
+pdao-beacon-chain-common = { version = "0.0.1", path = "../common"}
 serde-tc = "0.3.2"
 serde_json = { version = "1.0" }
 anyhow = { version = "1.0" }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,5 +12,11 @@ include = ["src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-rust_decimal = "1.25.0"
 serde_json = "1.0"
+borsh = { version = "0.9.3", optional = true }
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.0.0", features = ["derive"], optional = true }
+
+[features]
+polkadot = ["scale", "scale-info"]
+near = ["borsh"]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdao-beacon-chain-common"
-version = "0.0.0"
+version = "0.0.1"
 authors = ["PDAO Team <hello@postech-dao.xyz>"]
 edition = "2021"
 license = "MIT"

--- a/common/src/message.rs
+++ b/common/src/message.rs
@@ -7,17 +7,32 @@
 //!
 //! Messages will be JSON-encoded.
 
-use rust_decimal::prelude::*;
 use serde::{Deserialize, Serialize};
 
 /// A unit of a PBC-recored message that wraps the actual data.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(
+    feature = "polkadot",
+    derive(scale::Encode, scale::Decode, scale_info::TypeInfo)
+)]
+#[cfg_attr(
+    feature = "near",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 pub struct MessageDeliveryRecord {
     pub chain: String,
     pub message: DeliverableMessage,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(
+    feature = "polkadot",
+    derive(scale::Encode, scale::Decode, scale_info::TypeInfo)
+)]
+#[cfg_attr(
+    feature = "near",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 pub enum DeliverableMessage {
     FungibleTokenTransfer(FungibleTokenTransfer),
     NonFungibleTokenTransfer(NonFungibleTokenTransfer),
@@ -25,14 +40,30 @@ pub enum DeliverableMessage {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(
+    feature = "polkadot",
+    derive(scale::Encode, scale::Decode, scale_info::TypeInfo)
+)]
+#[cfg_attr(
+    feature = "near",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 pub struct FungibleTokenTransfer {
     pub token_id: String,
-    pub amount: Decimal,
+    pub amount: u128,
     pub receiver_address: String,
     pub contract_sequence: u64,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(
+    feature = "polkadot",
+    derive(scale::Encode, scale::Decode, scale_info::TypeInfo)
+)]
+#[cfg_attr(
+    feature = "near",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 pub struct NonFungibleTokenTransfer {
     pub collection_address: String,
     pub token_index: String,
@@ -41,6 +72,14 @@ pub struct NonFungibleTokenTransfer {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(
+    feature = "polkadot",
+    derive(scale::Encode, scale::Decode, scale_info::TypeInfo)
+)]
+#[cfg_attr(
+    feature = "near",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 pub struct Custom {
     pub message: String,
     pub contract_sequence: u64,

--- a/contract-common/Cargo.toml
+++ b/contract-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdao-colony-contract-common"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["PDAO Team <hello@postech-dao.xyz>"]
 edition = "2021"
 license = "MIT"
@@ -12,7 +12,7 @@ include = ["src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-pdao-beacon-chain-common = { version = "0.0.0", path = "../common"}
+pdao-beacon-chain-common = { version = "0.0.1", path = "../common"}
 borsh = { version = "0.9.3", optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"], optional = true }
 scale-info = { version = "2.0.0", features = ["derive"], optional = true }

--- a/contract-common/Cargo.toml
+++ b/contract-common/Cargo.toml
@@ -12,6 +12,12 @@ include = ["src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-rust_decimal = "1.25.0"
 pdao-beacon-chain-common = { version = "0.0.0", path = "../common"}
-borsh = { version = "0.9.3" }
+borsh = { version = "0.9.3", optional = true }
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.0.0", features = ["derive"], optional = true }
+
+[features]
+polkadot = ["scale", "scale-info", "pdao-beacon-chain-common/polkadot"]
+near = ["borsh", "pdao-beacon-chain-common/near"]
+

--- a/contract-common/src/light_client.rs
+++ b/contract-common/src/light_client.rs
@@ -4,7 +4,6 @@
 //!
 //! Later You will need to import `simperby-consensus` crate to use the actual implementation of the light client.
 
-use borsh::{BorshDeserialize, BorshSerialize};
 use pdao_beacon_chain_common::message;
 use serde::{Deserialize, Serialize};
 
@@ -18,7 +17,15 @@ pub type MerkleProof = String;
 /// A light client.
 ///
 /// NOTE: this is a dummy implementation.
-#[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(
+    feature = "polkadot",
+    derive(scale::Encode, scale::Decode, scale_info::TypeInfo)
+)]
+#[cfg_attr(
+    feature = "near",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 pub struct LightClient {
     pub height: u64,
     pub last_header: Header,


### PR DESCRIPTION
이제 `pdao-beacon-chain-common` 과 `pdao-colony-contract-common` 디펜던시에 넣으실때
`feature = ["near"]` 등과 같이 옵션을 주면 그 체인의 기능이 포함됩니다.